### PR TITLE
feat: --append custom dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ It will scan all your source files and fix the cases of [known names](./dict.jso
 
 Only the word including both uppercase and lowercase will be fixed. (e.g. `Github` -> `GitHub`; `github` and `GITHUB` will be left untouched).
 
+### Custom Dictionary
+
+You can also include your own terms in the dictionary using the `--append` option, e.g.
+
+```bash
+npx case-police --append my-dictionary.json --fix
+```
+
+The `--append` file must follow the same format as [dict.json](./dict.json).
+
 ### Using in CI
 
 Simply add `case-police` (without `--fix`) to your workflow and it will exit with a non-zero code for your CI to catch it.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { buildRegex, replace } from './utils'
 async function run() {
   const argv = minimist(process.argv.slice(2), {
     boolean: ['fix'],
-    string: ['append'],
+    string: ['append', 'd', 'dict'],
   })
 
   const ignore = [
@@ -29,8 +29,11 @@ async function run() {
   }
 
   let dictionary = { ...defaultDictionary }
-  if (argv.append && existsSync(argv.append)) dictionary = { ...dictionary, ...JSON.parse(await fs.readFile(argv.append, 'utf8')) }
-  else if (argv.append) console.log(c.red('An --append option was provided but the file does not exist\n'))
+  if (argv.append && existsSync(argv.append)) {
+    const appendDictionary = JSON.parse(await fs.readFile(argv.append, 'utf8'))
+    dictionary = { ...dictionary, ...appendDictionary }
+  }
+  else if (argv.append) { console.log(c.red('An --append option was provided but the file does not exist\n')) }
 
   const files = await fg('**/*.*', {
     ignore,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,13 @@ import parseIgnore from 'parse-gitignore'
 import isText from 'is-text-path'
 import pLimit from 'p-limit'
 import minimist from 'minimist'
-import dictionary from '../dict.json'
+import defaultDictionary from '../dict.json'
 import { buildRegex, replace } from './utils'
 
 async function run() {
   const argv = minimist(process.argv.slice(2), {
     boolean: ['fix'],
+    string: ['append'],
   })
 
   const ignore = [
@@ -26,6 +27,10 @@ async function run() {
     const gitignore = await fs.readFile('.gitignore', 'utf8')
     ignore.push(...parseIgnore(gitignore))
   }
+
+  let dictionary = { ...defaultDictionary }
+  if (argv.append && existsSync(argv.append)) dictionary = { ...dictionary, ...JSON.parse(await fs.readFile(argv.append, 'utf8')) }
+  else if (argv.append) console.log(c.red('An --append option was provided but the file does not exist\n'))
 
   const files = await fg('**/*.*', {
     ignore,


### PR DESCRIPTION
Closes #27 

Allows a user to provide their own .json file to be appended onto the default dictionary via the `--append` option
e.g. `npx case-police --append my-dictionary.json --fix`