### PR TITLE
feat: add STACKIT to case-police

### DIFF
--- a/dict.json
+++ b/dict.json
@@ -216,6 +216,7 @@
   "ssh": "SSH",
   "ssl": "SSL",
   "sso": "SSO",
+  "stackit": "STACKIT",
   "stackblitz": "StackBlitz",
   "sveltekit": "SvelteKit",
   "svg": "SVG",


### PR DESCRIPTION
Please add [STACKIT](https://www.stackit.de/) to case-police, as it get wrong written all the time. It is STACKIT not stackIT, StackIT, Stackit, etc.


Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

> Please read the [Contributions Guide](https://github.com/antfu/case-police/blob/main/CONTRIBUTING.md) before making Pull Requests.
