### PR TITLE
fix: correct case for Next.js

### DIFF
--- a/dict/softwares.json
+++ b/dict/softwares.json
@@ -132,7 +132,7 @@
   "neo4j": "Neo4j",
   "nestjs": "NestJS",
   "netbios": "NetBIOS",
-  "next.js": "Next.js",
+  "nextjs": "Next.js",
   "nocodb": "NocoDB",
   "node.js": "Node.js",
   "nosql": "NoSQL",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,6 +9,7 @@ describe('should', () => {
       `
 Github GitHub github GITHUB
 vscode VScode VS Code VSCODE vs code VS code
+nextjs Nextjs NextJS Next.js
 `,
       '',
     )
@@ -17,6 +18,7 @@ vscode VScode VS Code VSCODE vs code VS code
   "
   GitHub GitHub github GITHUB
   vscode VS Code VS Code VSCODE vs code VS Code
+  nextjs Next.js Next.js Next.js
   "
 `)
   })


### PR DESCRIPTION
This was added in #82 but it didn't account for the "NextJS" typo which is quite common

(should be "Next.js" as seen on https://nextjs.org)