### PR TITLE
NebulaGraph added

### DIFF
--- a/dict/softwares.json
+++ b/dict/softwares.json
@@ -142,6 +142,7 @@
   "mysql": "MySQL",
   "naive ui": "Naive UI",
   "naiveui": "NaiveUI",
+  "nebulagraph": "NebulaGraph",
   "neo4j": "Neo4j",
   "nestjs": "NestJS",
   "netbios": "NetBIOS",


### PR DESCRIPTION
Perviously we call it Nebula Graph, until this week, it’s rebranded as NebulaGraph, yes, we could finally be a thing in case police then! 
