### PR TITLE
fix: TypeError: pattern.startsWith is not a function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ async function run() {
     ignore.push(...parseIgnore(gitignore))
   }
   if (argv.ignore)
-    ignore.push(argv.ignore.split(',').map((i: string) => i.trim()))
+    ignore.push(...argv.ignore.split(',').map((i: string) => i.trim()))
   ignore = ignore.filter(Boolean)
 
   let dictionary = {}


### PR DESCRIPTION
Throwing `TypeError: pattern.startsWith is not a function` when using `ignore` option.