### PR TITLE
fix: Remove `nats` -> `NATS` for confusion with `NATs`

### DIFF
--- a/dict/abbreviates.json
+++ b/dict/abbreviates.json
@@ -59,7 +59,6 @@
   "mdn": "MDN",
   "mvc": "MVC",
   "mvvm": "MVVM",
-  "nats": "NATS",
   "nft": "NFT",
   "odbc": "ODBC",
   "ont": "ONT",


### PR DESCRIPTION
Fixes #138 