### PR TITLE
revert: UTF-8 support breaks some languages, revert PR #120

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,8 +11,6 @@ export const DISABLE_KEY = '@case-police-disable'
 
 export const IGNORE_REGEX = /@case-police-ignore\s+([^\s]+)/g
 
-export const UTF8_RANGE = '[\u0080-\uFFFF]'
-
 export function buildRegex(dictionary: Record<string, string>): RegExp {
   const keys = Object.keys(dictionary)
   const regex = new RegExp(`\\b(${keys.join('|')})\\b`, 'gi')
@@ -40,9 +38,6 @@ export async function replace(
   regex = regex || buildRegex(dict)
   let changed = false
   code = code.replace(regex, (_, key: string, index: number) => {
-    if (containsUTF8(code, key, index))
-      return _
-
     if (!key.match(/[A-Z]/) || !key.match(/[a-z]/))
       return _
     const lower = key.toLowerCase()
@@ -87,11 +82,4 @@ export async function loadAllPresets() {
     {},
     ...await Promise.all(files.map(file => resolvePreset(file.split('.')[0]))),
   )
-}
-
-function containsUTF8(code: string, key: string, index: number) {
-  const utf8Regex = new RegExp(`${UTF8_RANGE}`)
-  const head = code.charAt(index - 1)
-  const tail = code.charAt(index + key.length)
-  return utf8Regex.test(head) || utf8Regex.test(tail)
 }

--- a/test/dict/utf8.json
+++ b/test/dict/utf8.json
@@ -1,4 +1,0 @@
-{
-  "romania": "România",
-  "dom": "DOM"
-}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,3 @@
-import path from 'path'
-import { existsSync, promises as fs } from 'fs'
 import { describe, expect, it } from 'vitest'
 import { replace, resolvePreset } from '../src/utils'
 
@@ -12,6 +10,7 @@ describe('should', () => {
 Github GitHub github GITHUB
 vscode VScode VS Code VSCODE vs code VS code
 nextjs Nextjs NextJS Next.js
+GithubのVScode Github：
 `,
       '',
     )
@@ -21,6 +20,7 @@ nextjs Nextjs NextJS Next.js
   GitHub GitHub github GITHUB
   vscode VS Code VS Code VSCODE vs code VS Code
   nextjs Next.js Next.js Next.js
+  GitHubのVS Code GitHub：
   "
 `)
   })
@@ -40,33 +40,6 @@ describe('presets', () => {
 
     expect(replaced).toBe(`
       macOS Macbook
-    `)
-  })
-})
-
-describe('utf8', async () => {
-  let preset = {}
-  const presetFilePath = path.join(__dirname, './dict/utf8.json')
-  if (existsSync(presetFilePath)) {
-    const content = await fs.readFile(presetFilePath, 'utf-8')
-    preset = { ...JSON.parse(content) }
-  }
-
-  it('works', async () => {
-    const replaced = await replace(
-      `
-      Romania romania
-      Domâ Dom âDom ĕDomĕ
-    `,
-      '',
-      preset,
-    )
-
-    expect(replaced).toMatchInlineSnapshot(`
-      "
-            România romania
-            Domâ DOM âDom ĕDomĕ
-          "
     `)
   })
 })


### PR DESCRIPTION
> Please read the [Contributions Guide](https://github.com/antfu/case-police/blob/main/CONTRIBUTING.md) before making Pull Requests.

PR #120 breaks some languages such as Japanese and Chinese.
For example:
Githubのvscode Github的vscode Github：

`containsUTF8` will return true because it takes `Githubの`, `Github的` and `Github：` as a whole respectively, so the `Github` and `vscode` won't be corrected. UTF-8 support should be implemented in another way.