### PR TITLE
fix: deduplicate items

### DIFF
--- a/dict/brands.json
+++ b/dict/brands.json
@@ -4,7 +4,6 @@
   "bitbucket": "Bitbucket",
   "bytedance": "ByteDance",
   "circleci": "CircleCI",
-  "codesandbox": "CodeSandbox",
   "freecodecamp": "freeCodeCamp",
   "gitea": "Gitea",
   "gitee": "Gitee",

--- a/dict/brands.json
+++ b/dict/brands.json
@@ -4,7 +4,6 @@
   "bitbucket": "Bitbucket",
   "bytedance": "ByteDance",
   "circleci": "CircleCI",
-  "codepen": "CodePen",
   "codesandbox": "CodeSandbox",
   "freecodecamp": "freeCodeCamp",
   "gitea": "Gitea",

--- a/dict/softwares.json
+++ b/dict/softwares.json
@@ -226,7 +226,6 @@
   "springboot": "SpringBoot",
   "springcloud": "SpringCloud",
   "springmvc": "SpringMVC",
-  "sql": "SQL",
   "sqlite": "SQLite",
   "sqlserver": "SQLServer",
   "storybook": "Storybook",

--- a/test/duplicate.test.ts
+++ b/test/duplicate.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import fg from 'fast-glob'
+import { loadAllPresets, resolvePreset } from '../src/utils'
+
+describe('duplicate', () => {
+  it('detection', async () => {
+    const names = (await fg('dict/*.json')).map(name => name.replace('dict/', '').replace('.json', ''))
+    const presets = await Promise.all(names.map(async name => ({
+      name,
+      preset: await resolvePreset(name) as Record<string, string>,
+    })))
+
+    const allPresets = await loadAllPresets()
+
+    const duplicates: any[] = []
+
+    Object.keys(allPresets).forEach((value, key) => {
+      const matched = presets.filter(preset => preset.preset[value])
+      if (matched.length > 1) {
+        duplicates.push({
+          value,
+          matched: matched.map(p => p.name),
+        })
+      }
+    })
+
+    expect(duplicates).toEqual([])
+  })
+})


### PR DESCRIPTION
Hi,

This is a little update to remove a duplicate entry for `CodePen` from the previous release and the PR #145.
After running a litte test, I see another duplicate item for `CodeSandbox`.

I didn't push my test because it's the first I write, so I'm not sure it was done well:
```js
describe('duplicate', () => {
  it('detection', async () => {
    const presets = await Promise.all(
      [
        resolvePreset('abbreviates'),
        resolvePreset('brands'),
        resolvePreset('general'),
        resolvePreset('products'),
        resolvePreset('softwares'),
      ],
    )
    const count = presets.reduce((sum, item) => sum + Object.keys(item).length, 0)

    const allPresets = await loadAllPresets()
    const allPresetsCount = Object.keys(allPresets).length

    expect(count).toEqual(allPresetsCount)
  })
})
```


```bash
 FAIL  test/index.test.ts > duplicate > detection
AssertionError: expected 477 to deeply equal 476
 ❯ test/index.test.ts:66:18
     64|     const allPresetsCount = Object.keys(allPresets).length
     65| 
     66|     expect(count).toEqual(allPresetsCount)
       |                  ^
     67|   })
     68| })

  - Expected   "476"
  + Received   "477"

```

I could have used a `while/for` statement to remove entry until detect the duplicate item, but I don't know if it must be inside the test 🤷‍♂️.