### PR TITLE
fix: Use Vim rather than VIM

### DIFF
--- a/packages/case-police/dict/softwares.json
+++ b/packages/case-police/dict/softwares.json
@@ -267,7 +267,7 @@
   "upnp": "UPnP",
   "vercel": "Vercel",
   "videolan": "VideoLAN",
-  "vim": "VIM",
+  "vim": "Vim",
   "virtualbox": "VirtualBox",
   "visual studio": "Visual Studio",
   "visual studio code": "Visual Studio Code",


### PR DESCRIPTION
I don't think it was ever anything but "Vim", but it certainly is just that now.

Ref: https://www.vim.org/about.php (also its built-in `:help pronounce`)

According to the CONTRIBUTING guidelines, a more appropriate fix may be the deletion of that record altogether, if we don't think that people are likely to type Vim any way other than `vim`, `VIM` or `Vim`, and the only one that uses a mix of both cases is the correct one.
But I'd also apply the exact same logic to `Vulkan`, `Vercel`, `Rust`, which *are* in here.

In any case, I suspect that some folks may on occasion reach for `VIm`.
Let me know how best to resolve this :)

I'll mark this as a Draft for now.