### PR TITLE
chore: add ESLint plugin README, update packages metadata

### DIFF
--- a/packages/case-police/package.json
+++ b/packages/case-police/package.json
@@ -10,7 +10,8 @@
   "homepage": "https://github.com/antfu/case-police#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/antfu/case-police.git"
+    "url": "git+https://github.com/antfu/case-police.git",
+    "directory": "packages/case-police"
   },
   "bugs": {
     "url": "https://github.com/antfu/case-police/issues"

--- a/packages/eslint-plugin-case-police/README.md
+++ b/packages/eslint-plugin-case-police/README.md
@@ -1,0 +1,9 @@
+# eslint-plugin-case-police
+
+[![NPM version](https://img.shields.io/npm/v/case-police?color=a1b858&label=)](https://www.npmjs.com/package/eslint-plugin-case-police)
+
+ESLint plugin for [`case-police`](https://www.npmjs.com/package/case-police).
+
+## Documentation
+
+[Read full documentation](https://github.com/antfu/case-police#readme).

--- a/packages/eslint-plugin-case-police/package.json
+++ b/packages/eslint-plugin-case-police/package.json
@@ -1,8 +1,20 @@
 {
   "name": "eslint-plugin-case-police",
   "version": "2.1.0",
+  "description": "ESLint plugin for case-police",
+  "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/antfu",
   "homepage": "https://github.com/antfu/case-police#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antfu/case-police.git",
+    "directory": "packages/eslint-plugin-case-police"
+  },
+  "bugs": {
+    "url": "https://github.com/antfu/case-police/issues"
+  },
+  "keywords": ["eslint", "eslint-plugin"],
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
# Why

Spotted that `eslint-plugin-case-police` lacks README file and a package description when verifying the latests release on npm.

# How

Add simple README file for `eslint-plugin-case-police` package, add package metadata fields in `package.json`, and specify directories in monorepo according to https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository